### PR TITLE
Remove www from $docRootName

### DIFF
--- a/src/Pimcore/Composer/PluginInstaller.php
+++ b/src/Pimcore/Composer/PluginInstaller.php
@@ -20,7 +20,7 @@ class PluginInstaller extends LibraryInstaller
         }, $pluginName);
 		
 		
-		$docRootName = "./www"; 
+		$docRootName = "./"; 
 		if($configDocRoot = $this->composer->getConfig()->get("document-root-path")) {
 			$docRootName = rtrim($configDocRoot,"/");
 		}


### PR DESCRIPTION
having www in the $docRootName path installs the plugin under
- /www/plugins where it should be /plugins
